### PR TITLE
Release to crates.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -161,3 +161,18 @@ jobs:
         omitDraftDuringUpdate: true
         artifacts: ${{ env.ASSET }}
         artifactContentType: application/octet-stream
+
+  crates-release:
+    name: crates.io-release
+    needs: ['build-release']
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - run: cargo publish --token ${CRATES_TOKEN}
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,15 +11,21 @@ Read our blog post in [Hacker Noon](https://medium.com/hackernoon/ironhide-bette
 
 ## Installation
 
+### Cargo
+
+```bash
+cargo install ironhide
+```
+
 ### Nix
 
 #### Shell
 
-```console
+```bash
 nix run 'https://github.com/IronCoreLabs/ironhide.git'
 ```
 
-### Install From Source
+### Source
 
 Requires that you have `rust` set up on your system.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,4 +1,6 @@
 # Release Checklist
 
-* on master pushes or PRs CI is run
-* when a tag is pushed up a release will be run against it which will upload artifacts to a github release
+* update the version in `Cargo.toml` according to semver before tagging for release
+* push a tag matching the version in `Cargo.toml`.
+  * a release build will be run against it which will upload artifacts to a github release
+  * the version in `Cargo.toml` will be uploaded to crates.io


### PR DESCRIPTION
This adds a job to the release workflow to release to crates.io, using an API token repository secret.

Closes #62 