### PR TITLE
Workaround for stdlib setenv unsoundness

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[build]
-# allow local_offset to work on *nix. Sound for us because we're single threaded
-rustflags = ["--cfg", "unsound_local_offset"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.2
+
++ Resolve issue running binary when it is `cargo install`d. Previously returned an error 'Must be run on a system that has an OS time library.' when the group info and user device-list commands were invoked.
+
+## 1.0.1
+
++ Changed processing of the `-out` parameter so it could precede the list of files to be processed (for file encrypt and decrypt operations).
+
 ## 1.0.0
 
 + **Breaking Change**: Moved from a Node application to a Rust binary. Initial package manager support exists for `cargo install`, homebrew, arch linux, nix, chocolatey, and ubuntu. Instructions to compile from source are in the README if your platform doesn't have package manager support or a prebuilt binary.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +300,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +317,12 @@ checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
 dependencies = [
  "cache-padded",
 ]
+
+[[package]]
+name = "const_fn"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
 name = "convert_case"
@@ -382,6 +407,50 @@ dependencies = [
  "rand_core",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97abf9f0eca9e52b7f81b945524e76710e6cb2366aead23b7d4fbf72e281f888"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc32cc5fea1d894b77d269ddb9f192110069a8a9c1f1d441195fba90553dea3"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca220e4794c934dc6b1207c3b42856ad4c302f2df1712e9f8d2eec5afaacf1f"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -903,6 +972,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,7 +1038,7 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "ironhide"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "attohttpc",
  "atty",
@@ -964,6 +1057,8 @@ dependencies = [
  "serde_json",
  "textwrap 0.16.0",
  "time",
+ "tz-rs",
+ "tzdb",
  "yansi",
 ]
 
@@ -1069,6 +1164,15 @@ name = "libc"
 version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1256,15 +1360,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1766,6 +1861,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2077,13 +2178,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa 1.0.4",
- "libc",
- "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -2097,9 +2196,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
 ]
@@ -2206,6 +2305,25 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "tz-rs"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
+dependencies = [
+ "const_fn",
+]
+
+[[package]]
+name = "tzdb"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b8eecae212c0701db1974229094c8337855cfb02edddfa47be6b4fe369cf26"
+dependencies = [
+ "iana-time-zone",
+ "tz-rs",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironhide"
-version = "1.0.1"
+version = "1.0.2"
 authors = [ "IronCore Labs <info@ironcorelabs.com>" ]
 categories = [ "cryptography" ]
 description = "Tool to easily encrypt and decrypt files to users and groups. Similar to GPG, but usable at scale."
@@ -29,7 +29,7 @@ repository = "https://github.com/IronCoreLabs/ironhide"
 attohttpc = { version = "~0.23.1", features = ["form", "json", "tls-rustls", "compress"], default-features = false }
 atty = "~0.2.14"
 base64 = "~0.13"
-clap = { version = "~3.1.8", features = ["derive", "suggestions"] }
+clap = { version = "~3.1.8", features = ["cargo", "derive", "suggestions"] }
 derive_more = "~0.99.6"
 dirs = "~4.0"
 ironoxide = { version = "~2", features = [
@@ -44,8 +44,10 @@ rpassword = "~7.1"
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"
 textwrap = { version = "~0.16", features = ["terminal_size"] }
+tz-rs = { version = "~0.6.14", default-features = false }
+tzdb = { version = "~0.4.8", default-features = false, features = ["local"] }
 yansi = "~0.5"
 
 # these need to stay/be upated to ironoxide's versions
 itertools = "0.10"
-time = { version = "0.3.6", features = ["local-offset", "formatting", "alloc"] }
+time = { version = "0.3.6", features = ["formatting", "alloc"] }

--- a/src/file/info.rs
+++ b/src/file/info.rs
@@ -108,8 +108,16 @@ fn build_result_table(
                 })
                 .collect::<Vec<_>>()
                 .join("\n"),
-            metadata.created().to_offset(util::local_offset()).format(&util::time_format()).unwrap(),
-            metadata.last_updated().to_offset(util::local_offset()).format(&util::time_format()).unwrap()
+            metadata
+                .created()
+                .to_offset(util::local_offset())
+                .format(&util::time_format())
+                .unwrap(),
+            metadata
+                .last_updated()
+                .to_offset(util::local_offset())
+                .format(&util::time_format())
+                .unwrap()
         ]);
     }
     table

--- a/src/file/info.rs
+++ b/src/file/info.rs
@@ -108,8 +108,8 @@ fn build_result_table(
                 })
                 .collect::<Vec<_>>()
                 .join("\n"),
-            metadata.created(),
-            metadata.last_updated()
+            metadata.created().to_offset(util::local_offset()).format(&util::time_format()).unwrap(),
+            metadata.last_updated().to_offset(util::local_offset()).format(&util::time_format()).unwrap()
         ]);
     }
     table

--- a/src/group/list.rs
+++ b/src/group/list.rs
@@ -52,7 +52,7 @@ pub fn list_groups(sdk: &BlockingIronOxide) -> Result<(), String> {
                 cell!(Fw -> group.last_updated().
                                 to_offset(util::local_offset()).
                                 format(&util::time_format()).
-                                unwrap())
+                                unwrap()),
             ]));
         }
 

--- a/src/group/list.rs
+++ b/src/group/list.rs
@@ -45,8 +45,14 @@ pub fn list_groups(sdk: &BlockingIronOxide) -> Result<(), String> {
                 is_admin,
                 is_member,
                 cell!(Fw -> group.id().id()),
-                cell!(Fw -> group.created()),
-                cell!(Fw -> group.last_updated()),
+                cell!(Fw -> group.created().
+                                to_offset(util::local_offset()).
+                                format(&util::time_format()).
+                                unwrap()),
+                cell!(Fw -> group.last_updated().
+                                to_offset(util::local_offset()).
+                                format(&util::time_format()).
+                                unwrap())
             ]));
         }
 

--- a/src/group_maps.rs
+++ b/src/group_maps.rs
@@ -7,7 +7,7 @@ use prettytable::{color, Attr, Cell, Row};
 use std::collections::HashMap;
 use yansi::Paint;
 
-use crate::util::println_paint;
+use crate::util::{println_paint, local_offset, time_format};
 
 type GroupsByName = HashMap<GroupName, Vec<GroupMetaResult>>;
 type GroupsById = HashMap<GroupId, GroupMetaResult>;
@@ -114,8 +114,8 @@ fn group_choice_table(groups: &[GroupMetaResult]) -> prettytable::Table {
             cell!(Fw -> group.id().id()),
             is_admin,
             is_member,
-            cell!(Fw -> group.created()),
-            cell!(Fw -> group.last_updated()),
+            cell!(Fw -> group.created().to_offset(local_offset()).format(&time_format()).unwrap()),
+            cell!(Fw -> group.last_updated().to_offset(local_offset()).format(&time_format()).unwrap()),
         ]));
     }
 

--- a/src/group_maps.rs
+++ b/src/group_maps.rs
@@ -7,7 +7,7 @@ use prettytable::{color, Attr, Cell, Row};
 use std::collections::HashMap;
 use yansi::Paint;
 
-use crate::util::{println_paint, local_offset, time_format};
+use crate::util::{local_offset, println_paint, time_format};
 
 type GroupsByName = HashMap<GroupName, Vec<GroupMetaResult>>;
 type GroupsById = HashMap<GroupId, GroupMetaResult>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use crate::{file::FileSubcommands, group::GroupSubcommands};
+use clap::crate_version;
 use clap::Parser;
 use derive_more::{Display, Error};
 use ironoxide::{blocking::BlockingIronOxide, prelude::*};
@@ -18,7 +19,7 @@ mod util;
 
 /// Tool to easily encrypt and decrypt files to users and groups. Similar to GPG, but usable at scale.
 #[derive(Parser)]
-#[clap(version = "1.0.0", author = "IronCore Labs")]
+#[clap(version = crate_version!(), author = "IronCore Labs")]
 struct Ironhide {
     #[clap(subcommand)]
     subcmd: IronhideSubcommands,

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,7 +11,7 @@ use std::convert::TryFrom;
 use std::fmt::Display;
 use std::fs;
 use std::path::PathBuf;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 use std::{fs::File, path::Path};
 use time::format_description::FormatItem;
 use time::{format_description, UtcOffset};
@@ -174,7 +174,7 @@ pub fn local_offset() -> UtcOffset {
     let tz = tzdb::local_tz().unwrap_or(tzdb::time_zone::GMT);
     let duration_since_epoch = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .unwrap_or(Duration::default());
+        .unwrap_or_default();
     let default_local_time_type = tz::LocalTimeType::utc();
     let local_time_type = tz
         .find_local_time_type(duration_since_epoch.as_secs() as i64)


### PR DESCRIPTION
This is mostly a workaround until `time::UtcOffset::current_local_offset()` is sound again (see https://github.com/time-rs/time/issues/293)
It _is_ sound in our use case (we're single threaded so we can't possibly `setenv` at the same time as a timezone call), but we're not able to set `--cfg unsound_local_offset` in all build environments, because [crates.io ignores .cargo/config.toml files](https://github.com/rust-lang/cargo/issues/6025) and [build.rs](https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-cfgkeyvalue) scripts are run after dependencies are compiled.

Once https://github.com/rust-lang/rust/issues/27970 is fixed somehow and propagated out to time (or time has another solution for the problem in it's 293 issue), we can remove this workaround and consume it.

Otherwise this PR sets the clap version from the Cargo.toml version.