### PR TITLE
Create the .iron directory on first login if needed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -196,6 +196,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         keyring.set_password(serde_json::to_string(&device_context)?.as_str())?;
 
                         // as well as to the default file location
+                        std::fs::create_dir_all(dirs::home_dir().unwrap().join(".iron"))?;
                         std::fs::write(dirs::home_dir().unwrap().join(".iron/login"), &user.id())?;
                         std::fs::write(
                             dirs::home_dir().unwrap().join(".iron/keys"),


### PR DESCRIPTION
On new login, if the `~/.iron` directory doesn't exist, create it.