### PR TITLE
Simplify timestamp formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,6 +1050,7 @@ dependencies = [
  "ironoxide",
  "itertools",
  "keyring",
+ "once_cell",
  "prettytable-rs",
  "promptly",
  "rpassword",
@@ -1364,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opaque-debug"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ keyring = "~1.2.0"
 prettytable-rs = "~0.9"
 promptly = "~0.3"
 fancy-regex = "~0.10"
+once_cell = "~1.16"
 rpassword = "~7.1"
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"
@@ -50,4 +51,4 @@ yansi = "~0.5"
 
 # these need to stay/be upated to ironoxide's versions
 itertools = "0.10"
-time = { version = "0.3.6", features = ["formatting", "alloc"] }
+time = "0.3.6"

--- a/src/file/info.rs
+++ b/src/file/info.rs
@@ -108,16 +108,8 @@ fn build_result_table(
                 })
                 .collect::<Vec<_>>()
                 .join("\n"),
-            metadata
-                .created()
-                .to_offset(util::local_offset())
-                .format(&util::time_format())
-                .unwrap(),
-            metadata
-                .last_updated()
-                .to_offset(util::local_offset())
-                .format(&util::time_format())
-                .unwrap()
+            util::time_format(metadata.created()),
+            util::time_format(metadata.last_updated()),
         ]);
     }
     table

--- a/src/group/info.rs
+++ b/src/group/info.rs
@@ -46,15 +46,12 @@ fn build_table(result: Result<GetResult, IronOxideErr>) -> prettytable::Table {
     let mut table = table![];
     match result {
         Ok(get_result) => {
-            let created = get_result.created.to_offset(util::local_offset());
-            let updated = get_result.updated.to_offset(util::local_offset());
-
             table.add_row(row![Fbb->"Group", get_result.name]);
             table.add_row(row![Fbb->"ID", get_result.id]);
             table.add_row(create_row("Admin", get_result.is_admin));
             table.add_row(create_row("Member", get_result.is_member));
-            table.add_row(row![Fbb->"Created", created.format(&util::time_format()).unwrap()]);
-            table.add_row(row![Fbb->"Updated", updated.format(&util::time_format()).unwrap()]);
+            table.add_row(row![Fbb->"Created", util::time_format(&get_result.created)]);
+            table.add_row(row![Fbb->"Updated", util::time_format(&get_result.updated)]);
             table.add_row(row![Fbb->"Admins", get_result.admins.join("\n")]);
             table.add_row(row![Fbb->"Members", get_result.members.join("\n")]);
         }

--- a/src/group/list.rs
+++ b/src/group/list.rs
@@ -45,14 +45,8 @@ pub fn list_groups(sdk: &BlockingIronOxide) -> Result<(), String> {
                 is_admin,
                 is_member,
                 cell!(Fw -> group.id().id()),
-                cell!(Fw -> group.created().
-                                to_offset(util::local_offset()).
-                                format(&util::time_format()).
-                                unwrap()),
-                cell!(Fw -> group.last_updated().
-                                to_offset(util::local_offset()).
-                                format(&util::time_format()).
-                                unwrap()),
+                cell!(Fw -> util::time_format(group.created())),
+                cell!(Fw -> util::time_format(group.last_updated())),
             ]));
         }
 

--- a/src/group_maps.rs
+++ b/src/group_maps.rs
@@ -7,7 +7,7 @@ use prettytable::{color, Attr, Cell, Row};
 use std::collections::HashMap;
 use yansi::Paint;
 
-use crate::util::{local_offset, println_paint, time_format};
+use crate::util::{println_paint, time_format};
 
 type GroupsByName = HashMap<GroupName, Vec<GroupMetaResult>>;
 type GroupsById = HashMap<GroupId, GroupMetaResult>;
@@ -114,8 +114,8 @@ fn group_choice_table(groups: &[GroupMetaResult]) -> prettytable::Table {
             cell!(Fw -> group.id().id()),
             is_admin,
             is_member,
-            cell!(Fw -> group.created().to_offset(local_offset()).format(&time_format()).unwrap()),
-            cell!(Fw -> group.last_updated().to_offset(local_offset()).format(&time_format()).unwrap()),
+            cell!(Fw -> time_format(group.created())),
+            cell!(Fw -> time_format(group.last_updated())),
         ]));
     }
 

--- a/src/user/device_list.rs
+++ b/src/user/device_list.rs
@@ -33,9 +33,13 @@ pub fn list_devices(sdk: &BlockingIronOxide) -> Result<(), String> {
         } else {
             ""
         };
-        let created_dt = device.created().to_offset(util::local_offset());
-        let updated_dt = device.last_updated().to_offset(util::local_offset());
-        table.add_row(row![device.id().id(), device_name, created_dt.format(&util::time_format()).unwrap(), updated_dt.format(&util::time_format()).unwrap(), Fgb->current_device]);
+        table.add_row(row![
+            device.id().id(),
+            device_name,
+            util::time_format(device.created()),
+            util::time_format(device.last_updated()),
+            Fgb->current_device,
+        ]);
     }
     table.printstd();
     Ok(())

--- a/src/util.rs
+++ b/src/util.rs
@@ -162,20 +162,24 @@ pub fn println_paint(paint: yansi::Paint<String>) {
     }
 }
 
-pub fn time_format(ts: &time::OffsetDateTime) -> String {
+pub fn time_format(utc_ts: &time::OffsetDateTime) -> String {
     static LOCAL_TZ: Lazy<tz::TimeZoneRef<'static>> =
         Lazy::new(|| tzdb::local_tz().unwrap_or(tzdb::time_zone::GMT));
-    if let Ok(ts) = tz::DateTime::from_total_nanoseconds(ts.unix_timestamp_nanos(), *LOCAL_TZ) {
-        let y = ts.year();
-        let m = ts.month();
-        let d = ts.month_day();
-        let h = ts.hour();
-        let i = ts.minute();
-        let s = ts.second();
-        let z = ts.local_time_type().time_zone_designation();
+    if let Ok(adjusted_local_time) =
+        tz::DateTime::from_total_nanoseconds(utc_ts.unix_timestamp_nanos(), *LOCAL_TZ)
+    {
+        let y = adjusted_local_time.year();
+        let m = adjusted_local_time.month();
+        let d = adjusted_local_time.month_day();
+        let h = adjusted_local_time.hour();
+        let i = adjusted_local_time.minute();
+        let s = adjusted_local_time.second();
+        let z = adjusted_local_time
+            .local_time_type()
+            .time_zone_designation();
         format!("{y:04}-{m:02}-{d:02} {h:02}:{i:02}:{s:02} ({z})")
     } else {
-        format!("{ts:?}")
+        format!("{utc_ts:?}")
     }
 }
 


### PR DESCRIPTION
This PR makes the tool use `tz-rs` to convert a timestamp to the user's local time zone, and respect changes to their DST since the creation of a device. The relevant time zone designation is printed in the resulting string.

This PR further removes the usage of `unwrap()` from formatting a timestamp. On error `Debug::fmt()` is used to express the timestamp.

And lastly the PR makes divining the user's timezone lazy and caching.

Resolves #82
Resolves #83