### PR TITLE
Maintain path for output file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,7 +1038,7 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "ironhide"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "attohttpc",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ ironoxide = { version = "~2", features = [
     "tls-rustls",
 ], default-features = false }
 
-# these need to stay/be upated to ironoxide's versions
+# this needs to stay/be upated to ironoxide's version
 itertools = "0.10"
 keyring = "~1.2.0"
 once_cell = "~1.16"
@@ -47,6 +47,7 @@ rpassword = "~7.1"
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"
 textwrap = { version = "~0.16", features = ["terminal_size"] }
+# this needs to stay/be upated to ironoxide's version
 time = "0.3.6"
 tz-rs = { version = "~0.6.14", default-features = false }
 tzdb = { version = "~0.5.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ironhide"
 version = "1.0.4"
-authors = [ "IronCore Labs <info@ironcorelabs.com>" ]
-categories = [ "cryptography" ]
+authors = ["IronCore Labs <info@ironcorelabs.com>"]
+categories = ["cryptography"]
 description = "Tool to easily encrypt and decrypt files to users and groups. Similar to GPG, but usable at scale."
 documentation = "https://docs.rs/ironhide"
 edition = "2021"
@@ -22,7 +22,6 @@ keywords = [
 license = "AGPL-3.0-only"
 readme = "README.md"
 repository = "https://github.com/IronCoreLabs/ironhide"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -32,23 +31,23 @@ base64 = "~0.13"
 clap = { version = "~3.1.8", features = ["cargo", "derive", "suggestions"] }
 derive_more = "~0.99.6"
 dirs = "~4.0"
+fancy-regex = "~0.10"
 ironoxide = { version = "~2", features = [
     "blocking",
     "tls-rustls",
 ], default-features = false }
+
+# these need to stay/be upated to ironoxide's versions
+itertools = "0.10"
 keyring = "~1.2.0"
+once_cell = "~1.16"
 prettytable-rs = "~0.9"
 promptly = "~0.3"
-fancy-regex = "~0.10"
-once_cell = "~1.16"
 rpassword = "~7.1"
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"
 textwrap = { version = "~0.16", features = ["terminal_size"] }
+time = "0.3.6"
 tz-rs = { version = "~0.6.14", default-features = false }
 tzdb = { version = "~0.5.0", default-features = false }
 yansi = "~0.5"
-
-# these need to stay/be upated to ironoxide's versions
-itertools = "0.10"
-time = "0.3.6"

--- a/src/file/decrypt.rs
+++ b/src/file/decrypt.rs
@@ -4,6 +4,7 @@ use ironoxide::prelude::BlockingIronOxide;
 use std::{
     fs::{self, File, OpenOptions},
     io::{self, Read, Write},
+    path::Path,
     path::PathBuf,
 };
 use yansi::Paint;
@@ -110,14 +111,16 @@ pub fn decrypt_files(
                         path.display()
                     )
                 })?;
-                let out_path = out.clone().unwrap_or(
-                    path.file_stem()
-                        .ok_or(format!(
+                let in_parent = path.parent().ok_or(format!(
+                    "Failed to find parent of input path {}.",
+                    path.display()
+                ))?;
+                let out_path =
+                    out.clone()
+                        .unwrap_or(in_parent.join(Path::new(path.file_stem().ok_or(format!(
                             "Failed to extract default output file name from input path {}.",
                             path.display()
-                        ))?
-                        .into(),
-                );
+                        ))?)));
                 let (out_writer, out_logged_path) = get_writer_and_path(out_path)?;
                 decrypt_file(sdk, encrypted_document, out_writer, delete, Some(path))?;
                 if files.len() == 1 {


### PR DESCRIPTION
If the input includes a relative or absolute path, and no output is specified, write the output file into the same directory as the input file.

Signed-off-by: Bob Wall <bob.wall@ironcorelabs.com>