### PR TITLE
Add M1 build to the build/release matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,6 +58,8 @@ jobs:
           rust: nightly
         - build: macos
           os: macos-12
+        - os: [self-hosted, macOS, ARM64]
+          target: aarch64-apple-darwin
         - build: win-msvc
           os: windows-2022
         - build: win-gnu

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,7 @@
 name: ci
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
   push:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,7 @@ jobs:
         - beta
         - nightly
         - macos
+        - macos-arm64
         - win-msvc
         - win-gnu
         include:
@@ -58,7 +59,8 @@ jobs:
           rust: nightly
         - build: macos
           os: macos-12
-        - os: [self-hosted, macOS, ARM64]
+        - build: macos-arm64
+          os: [self-hosted, macOS, ARM64]
           target: aarch64-apple-darwin
         - build: win-msvc
           os: windows-2022

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,7 @@ jobs:
       RUST_BACKTRACE: 1
     strategy:
       matrix:
-        build: [linux, linux-arm64, linux-arm, macos, win-msvc, win-gnu]
+        build: [linux, linux-arm64, linux-arm, macos, macos-arm64, win-msvc, win-gnu]
         include:
         - build: linux
           os: ubuntu-22.04
@@ -81,6 +81,9 @@ jobs:
         - build: macos
           os: macos-12
           target: x86_64-apple-darwin
+        - build: macos-arm64
+          os: [self-hosted, macOS, ARM64]
+          target: aarch64-apple-darwin
         - build: win-msvc
           os: windows-2022
           target: x86_64-pc-windows-msvc
@@ -127,7 +130,7 @@ jobs:
       run: ${{ env.CARGO }} build --verbose --release ${{ env.TARGET_FLAGS }}
 
     - name: Strip release binary (linux and mac)
-      if: matrix.build == 'linux' || matrix.build == 'macos'
+      if: matrix.build == 'linux' || matrix.build == 'macos' || matrix.build == 'macos-arm64'
       run: strip "target/${{ matrix.target }}/release/ironhide"
 
     - name: Strip release binary (arm)


### PR DESCRIPTION
If https://github.com/IronCoreLabs/search-edeks sticks around we should pull the release workflow here out into https://github.com/IronCoreLabs/workflows/, switch off dtolnay's toolchain action. and use the workflow in both places. Only difference right now is that this repo does a crate publish and that one doesn't.