### PR TITLE
Fix flake builder -- again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,7 +1070,7 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "ironhide"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "attohttpc",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironhide"
-version = "1.0.8"
+version = "1.0.9"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 categories = ["cryptography"]
 description = "Tool to easily encrypt and decrypt files to users and groups. Similar to GPG, but usable at scale."

--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,5 @@
 {
   "nodes": {
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1725863722,
-        "narHash": "sha256-YBcCMVp9RrN2rgqhsMhpu/iw7L8z17N4fp4A129IZ3w=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "c30b094741641eef4a7200a5d52a8a16f0f345c6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -73,27 +52,9 @@
     },
     "root": {
       "inputs": {
-        "fenix": "fenix",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1725630423,
-        "narHash": "sha256-gNCLk3Zg7JlAwmWbVHTH6f3+iqdeQ4fheOotCZy8x5M=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "08c7bbc2dbe4dcc8968484f1a0e1e6fe7a1d4f6d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
       }
     },
     "rust-overlay": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1725863722,
+        "narHash": "sha256-YBcCMVp9RrN2rgqhsMhpu/iw7L8z17N4fp4A129IZ3w=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "c30b094741641eef4a7200a5d52a8a16f0f345c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -52,9 +73,27 @@
     },
     "root": {
       "inputs": {
+        "fenix": "fenix",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1725630423,
+        "narHash": "sha256-gNCLk3Zg7JlAwmWbVHTH6f3+iqdeQ4fheOotCZy8x5M=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "08c7bbc2dbe4dcc8968484f1a0e1e6fe7a1d4f6d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "rust-overlay": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,27 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
-      "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
-        "type": "github"
+      "inputs": {
+        "systems": "systems"
       },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -32,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678654296,
-        "narHash": "sha256-aVfw3ThpY7vkUeF1rFy10NAkpKDS2imj3IakrzT0Occ=",
+        "lastModified": 1725634671,
+        "narHash": "sha256-v3rIhsJBOMLR8e/RNWxr828tB+WywYIoajrZKFM+0Gg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5a1dc8acd977ff3dccd1328b7c4a6995429a656b",
+        "rev": "574d1eac1c200690e27b8eb4e24887f8df7ac27c",
         "type": "github"
       },
       "original": {
@@ -48,11 +36,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1665296151,
-        "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
+        "lastModified": 1718428119,
+        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
+        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
         "type": "github"
       },
       "original": {
@@ -71,20 +59,34 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1707963067,
-        "narHash": "sha256-1vmNGzAIenei+keS8vIUNYVkEGwEwF+3FR7/bXU/r18=",
+        "lastModified": 1725848835,
+        "narHash": "sha256-u4lCr+tOEWhsFiww5G04U5jUNzaQJi0/ZMIDGiLeT14=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "23f224428779539eb4dc13f6a77c97ffe4680d74",
+        "rev": "2ef910a6276a2f34513d18f2f826a8dea72c3b3f",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,6 @@
     flake-utils.lib.eachDefaultSystem (system: let
       overlays = [(import rust-overlay)];
       pkgs = import nixpkgs {inherit system overlays;};
-      rusttoolchain =
-        pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
       toolchainToml = builtins.fromTOML (builtins.readFile ./rust-toolchain.toml);
       cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
     in rec {
@@ -52,7 +50,7 @@
       # nix develop
       devShells.default = pkgs.mkShell {
         buildInputs = with pkgs;
-          [rusttoolchain]
+          [(pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)]
           ++ lib.optionals stdenv.isDarwin
           (with darwin.apple_sdk.frameworks; [Security SystemConfiguration]);
       };

--- a/flake.nix
+++ b/flake.nix
@@ -5,10 +5,6 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     rust-overlay.url = "github:oxalica/rust-overlay";
     flake-utils.url = "github:numtide/flake-utils";
-    fenix = {
-      url = "github:nix-community/fenix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs = {
@@ -16,27 +12,25 @@
     nixpkgs,
     rust-overlay,
     flake-utils,
-    fenix,
-    ...
   }:
     flake-utils.lib.eachDefaultSystem (system: let
       overlays = [(import rust-overlay)];
       pkgs = import nixpkgs {inherit system overlays;};
-      toolchainToml = builtins.fromTOML (builtins.readFile ./rust-toolchain.toml);
+      rusttoolchain =
+        pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
       cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
     in rec {
       # `nix build`
       packages = {
-        # ironhide = (pkgs.makeRustPlatform (fenix.packages.${system}.fromManifest toolchainToml)).buildRustPackage {
         ironhide =
-          (pkgs.makeRustPlatform (fenix.packages.${system}.fromToolchainName {
-            name = toolchainToml.toolchain.channel;
-            sha256 = "sha256-3jVIIf5XPnUU1CRaTyAiO0XHVbJl12MSx3eucTXCjtE=";
-          }))
+          (pkgs.makeRustPlatform {
+            cargo = rusttoolchain;
+            rustc = rusttoolchain;
+          })
           .buildRustPackage {
             # ironhide = pkgs.rustPlatform.buildRustPackage {
             pname = cargoToml.package.name;
-            inherit (cargoToml.package) version name;
+            inherit (cargoToml.package) version;
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
             nativeBuildInputs = with pkgs;
@@ -50,7 +44,7 @@
       # nix develop
       devShells.default = pkgs.mkShell {
         buildInputs = with pkgs;
-          [(pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)]
+          [rusttoolchain]
           ++ lib.optionals stdenv.isDarwin
           (with darwin.apple_sdk.frameworks; [Security SystemConfiguration]);
       };

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,10 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     rust-overlay.url = "github:oxalica/rust-overlay";
     flake-utils.url = "github:numtide/flake-utils";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {
@@ -12,6 +16,7 @@
     nixpkgs,
     rust-overlay,
     flake-utils,
+    fenix,
     ...
   }:
     flake-utils.lib.eachDefaultSystem (system: let
@@ -19,20 +24,28 @@
       pkgs = import nixpkgs {inherit system overlays;};
       rusttoolchain =
         pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+      toolchainToml = builtins.fromTOML (builtins.readFile ./rust-toolchain.toml);
       cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
     in rec {
       # `nix build`
       packages = {
-        ironhide = pkgs.rustPlatform.buildRustPackage {
-          pname = cargoToml.package.name;
-          version = cargoToml.package.version;
-          src = ./.;
-          cargoLock.lockFile = ./Cargo.lock;
-          nativeBuildInputs = with pkgs;
-            [rusttoolchain]
-            ++ pkgs.lib.optionals pkgs.stdenv.isDarwin
-            (with pkgs.darwin.apple_sdk.frameworks; [Security SystemConfiguration]);
-        };
+        # ironhide = (pkgs.makeRustPlatform (fenix.packages.${system}.fromManifest toolchainToml)).buildRustPackage {
+        ironhide =
+          (pkgs.makeRustPlatform (fenix.packages.${system}.fromToolchainName {
+            name = toolchainToml.toolchain.channel;
+            sha256 = "sha256-3jVIIf5XPnUU1CRaTyAiO0XHVbJl12MSx3eucTXCjtE=";
+          }))
+          .buildRustPackage {
+            # ironhide = pkgs.rustPlatform.buildRustPackage {
+            pname = cargoToml.package.name;
+            inherit (cargoToml.package) version name;
+            src = ./.;
+            cargoLock.lockFile = ./Cargo.lock;
+            nativeBuildInputs = with pkgs;
+              [rusttoolchain]
+              ++ lib.optionals stdenv.isDarwin
+              (with darwin.apple_sdk.frameworks; [Security SystemConfiguration]);
+          };
         default = packages.ironhide;
       };
 
@@ -40,8 +53,8 @@
       devShells.default = pkgs.mkShell {
         buildInputs = with pkgs;
           [rusttoolchain]
-          ++ pkgs.lib.optionals pkgs.stdenv.isDarwin
-          (with pkgs.darwin.apple_sdk.frameworks; [Security SystemConfiguration]);
+          ++ lib.optionals stdenv.isDarwin
+          (with darwin.apple_sdk.frameworks; [Security SystemConfiguration]);
       };
     });
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.80.1"
+channel = "1.76.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.76.0"
+channel = "1.80.1"


### PR DESCRIPTION
So... turns out that last time it was actually not building with the rust toolchain that was specified and there was an error that was thrown when building ironhide from my system config which wasn't thrown otherwise.  Things would have worked right in a developer shell and things appeared to work right when calling `nix run` or `nix build`.

The critical change is to go from using the `pkgs.rustPlatform` which is not overriden by oxalaca to calling `pkgs.makeRustPlatform` and passing in the oxalaca binaries needed for the build (cargo and rustc).

I pushed this up as a branch and had my system config point to this branch to test it. It does work now.  Sorry for the multiple PRs.