### PR TITLE
Pin IronCore workflow tags to their dotted names

### DIFF
--- a/.github/workflows/rust-cargo-update.yaml
+++ b/.github/workflows/rust-cargo-update.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   rust-cargo-update:
-    uses: IronCoreLabs/workflows/.github/workflows/rust-cargo-update.yaml@rust-cargo-update-v1
+    uses: IronCoreLabs/workflows/.github/workflows/rust-cargo-update.yaml@rust-cargo-update-v1.0.0
     with:
       reviewer: ${{inputs.reviewer}}
     secrets: inherit


### PR DESCRIPTION
`IronCoreLabs/workflows` now publishes its floating tags under dotted names:
`rust-ci-v3.0.0` instead of `rust-ci-v3`. Same commit, same auto-updating
behavior — but Dependabot can parse the dotted form, so this repo will get a PR
when a workflow's next major ships.

The undotted tags are frozen and no longer move, so a repo left on them stops
receiving workflow updates entirely.

See https://github.com/IronCoreLabs/workflows/blob/main/RELEASING.md
